### PR TITLE
Use dev branch, Debian Stretch, Tesseract 3 and Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # audiveris-docker-images
 
-This container will convert all images in jpg or png (originally forked repo: PDF) to mxl (MusicXML) so you can further edit it with tools like MuseScore.
+This container will convert all jpg, png and pdf to mxl (MusicXML) so you can further edit it with tools like MuseScore.
 
-All *.pdf in `/path/to/input` will be converted and saved to `/path/to/output`
+All *.pdf, *.jpg and *.png in `/path/to/input` will be converted and saved to `/path/to/output`
 
 Usage
 -------------

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,9 @@ version: "3.7"
 
 services:
     audiveris:
-        image: s0urc10ud/audiveris-docker-images
+        build: .
+        image: toprock/audiveris
         container_name: audiveris-converter
         volumes:
-            -  "$PWD/input:/input/"
-            -  "$PWD/output:/output/"
+            -  "./input:/input/"
+            -  "./output:/output/"


### PR DESCRIPTION
Sadly I had to go back to Debian Stretch but at least everything is working!

I tried to run examples https://github.com/Audiveris/audiveris/tree/master/data/examples and it works for most of them.
